### PR TITLE
heartex/label-studio Allow to skip mandatory env variables validation check

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.tpl linguist-detectable=false

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -36,4 +36,5 @@
 - [ ] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
 - [ ] Input Validation completed with `values.schema.json`.
 - [ ] Variables are documented in the values.yaml and added to the `README.md`.
+- [ ] Changelog updated to describe new changes/fixes.
 - [ ] Title of the pull request follows this pattern [heartex/<name_of_the_chart>] Descriptive title

--- a/heartex/label-studio/CHANGELOG.md
+++ b/heartex/label-studio/CHANGELOG.md
@@ -6,9 +6,15 @@
 
 * 
 
-### Fixed
+### Fixes
 
-* 
+## 1.0.2
+### Fixes
+* Allow to skip mandatory env variables validation step using `.Values.checkConfig.skipEnvValues`
+
+## 1.0.1
+### Improvements
+* Override clusterDomain using `.Values.clusterDomain`
 
 
 ## 1.0.0

--- a/heartex/label-studio/Chart.yaml
+++ b/heartex/label-studio/Chart.yaml
@@ -5,7 +5,7 @@ home: https://labelstud.io/
 type: application
 icon: https://raw.githubusercontent.com/heartexlabs/label-studio/master/images/logo.png
 # Chart version
-version: 1.0.1
+version: 1.0.2
 # Label Studio release version
 appVersion: "1.7.0"
 kubeVersion: ">= 1.14.0-0"

--- a/heartex/label-studio/README.md
+++ b/heartex/label-studio/README.md
@@ -381,11 +381,12 @@ Supported only in LabelStudio Enterprise
 | `redis.auth.enabled`       | Enable password authentication	                                                                         | `false`       |
 
 ### Other parameters
-| Parameter            | Description                                      | Default         |
-|----------------------|--------------------------------------------------|-----------------|
-| upgradeCheck.enabled | Enable upgradecheck                              | `false`         |
-| ci                   | Indicate that deployment running for CI purposes | `false`         |
-| clusterDomain        | Kubernetes Cluster Domain                        | `cluster.local` |
+| Parameter                 | Description                                      | Default         |
+|---------------------------|--------------------------------------------------|-----------------|
+| upgradeCheck.enabled      | Enable upgradecheck                              | `false`         |
+| ci                        | Indicate that deployment running for CI purposes | `false`         |
+| clusterDomain             | Kubernetes Cluster Domain                        | `cluster.local` |
+| checkConfig.skipEnvValues | Skip validation for env variables                | `false`         |
 
 #### The `global.extraEnvironmentVars` usage
 

--- a/heartex/label-studio/templates/_checkConfig.tpl
+++ b/heartex/label-studio/templates/_checkConfig.tpl
@@ -58,7 +58,7 @@ Due to gotpl scoping, we can't make use of `range`, so we have to add action lin
 {{/* Ensure that LABEL_STUDIO_HOST is set if ingress enabled: false */}}
 {{- define "ls.checkConfig.labelStudioHostisSet" -}}
 {{- if and (not .Values.app.ingress.enabled) (not .Values.global.extraEnvironmentVars.LABEL_STUDIO_HOST) -}}
-ls-app:
+Label Studio:
   Service: If `.Values.app.ingress.enabled` set to `false`, please define `.Values.global.extraEnvironmentVars.LABEL_STUDIO_HOST` instead.
   It should include http/https scheme and a hostname available outside of the k8s cluster, e.g.: http://host.com
 {{- end -}}
@@ -69,7 +69,7 @@ ls-app:
 {{- define "ls.checkConfig.labelStudioHostScheme" -}}
 {{- if .Values.global.extraEnvironmentVars.LABEL_STUDIO_HOST -}}
 {{- if and (not .Values.app.ingress.enabled) (not (hasPrefix "http" .Values.global.extraEnvironmentVars.LABEL_STUDIO_HOST)) -}}
-ls-app:
+Label Studio:
   Ingress: Please define scheme http/https in `.Values.global.extraEnvironmentVars.LABEL_STUDIO_HOST`.
   If you're not going to expose the app by 80/443 ports, you also should include the correct port number.
 {{- end -}}
@@ -79,32 +79,36 @@ ls-app:
 
 {{/* Ensure that redis host is set */}}
 {{- define "lse.checkConfig.redisHost" -}}
+{{- if not .Values.checkConfig.skipEnvValues }}
 {{- if and (.Values.enterprise.enabled) (not .Values.redis.enabled) (not .Values.global.redisConfig.host) -}}
 Label Studio Enterprise:
   Redis: Redis is required for Label Studio Enterpise. Please set Redis host in `.Values.global.redisConfig.host`
+{{- end -}}
 {{- end -}}
 {{- end -}}
 {{/* END ls.checkConfig.redisHost */}}
 
 {{/* Ensure that postgresql host is set */}}
 {{- define "ls.checkConfig.pgConfig" -}}
+{{- if not .Values.checkConfig.skipEnvValues }}
 {{- if (not .Values.postgresql.enabled) -}}
 {{- if (not .Values.global.pgConfig.host) -}}
-ls-app:
+Label Studio:
   PostgreSQL: PostgreSQL is required for Label Studio. Please set PostgreSQL host in `.Values.global.pgConfig.host`
 {{ end -}}
 {{- if (not .Values.global.pgConfig.dbName) -}}
-ls-app:
+Label Studio:
   PostgreSQL: Please set database name in `.Values.global.pgConfig.dbName`
 {{ end -}}
 {{- if (not .Values.global.pgConfig.userName) -}}
-ls-app:
+Label Studio:
   PostgreSQL: Please set username in `.Values.global.pgConfig.userName`
 {{ end -}}
 {{- if or (not .Values.global.pgConfig.password.secretName) (not .Values.global.pgConfig.password.secretKey) -}}
-ls-app:
+Label Studio:
   PostgreSQL: Please ensure that PostgreSQL's password was uploaded in k8s secrets and expose it in `.Values.global.pgConfig.password.secretName` and `.Values.global.pgConfig.password.secretKey`
 {{ end -}}
+{{- end -}}
 {{- end -}}
 {{- end -}}
 {{/* END ls.checkConfig.pgConfig */}}
@@ -134,12 +138,12 @@ Label Studio Enterprise:
 {{- $s3HelpLink := "Please, check our documentation: https://labelstud.io/guide/persistent_storage.html#Set-up-Amazon-S3" -}}
 {{- if eq .Values.global.persistence.type "s3" -}}
 {{- if (not .Values.global.persistence.config.s3.region) -}}
-ls-app:
+Label Studio:
   Persistence(s3): AWS S3 bucket region is required. Please set it in `.Values.global.persistence.config.s3.region`
   {{ $s3HelpLink }}
 {{- end -}}
 {{- if (not .Values.global.persistence.config.s3.bucket)}}
-ls-app:
+Label Studio:
   Persistence(s3): AWS S3 bucket name is required. Please set it in `.Values.global.pgConfig.dbName`
   {{ $s3HelpLink }}
 {{- end -}}
@@ -152,7 +156,7 @@ ls-app:
 {{- $azureHelpLink := "Please, check our documentation: https://labelstud.io/guide/persistent_storage.html#Set-up-Microsoft-Azure-Storage" -}}
 {{- if eq .Values.global.persistence.type "azure" -}}
 {{- if (not .Values.global.persistence.config.azure.containerName) -}}
-ls-app:
+Label Studio:
   Persistence(azure): Azure container name is required. Please set it in `.Values.global.persistence.config.azure.containerName`
   {{ $azureHelpLink }}
 {{- end -}}
@@ -165,12 +169,12 @@ ls-app:
 {{- $gcsHelpLink := "Please, check our documentation: https://labelstud.io/guide/persistent_storage.html#Set-up-Google-Cloud-Storage" -}}
 {{- if eq .Values.global.persistence.type "gcs" -}}
 {{- if (not .Values.global.persistence.config.gcs.bucket) -}}
-ls-app:
+Label Studio:
   Persistence(gcs): GCS bucket name is required. Please set it in `.Values.global.persistence.config.gcs.bucket`
   {{ $gcsHelpLink }}
 {{- end -}}
 {{- if (not .Values.global.persistence.config.gcs.projectID) -}}
-ls-app:
+Label Studio:
   Persistence(gcs): GCS project ID is required. Please set it in `.Values.global.persistence.config.gcs.projectID`
   {{ $gcsHelpLink }}
 {{- end -}}
@@ -183,7 +187,7 @@ ls-app:
 {{- if .Values.global.featureFlags -}}
 {{- range $key, $value := .Values.global.featureFlags -}}
 {{- if and (not (hasPrefix "ff_" (printf "%s" $key))) (not (hasPrefix "fflag_" (printf "%s" $key))) }}
-ls-app:
+Label Studio:
   Feature Flags: flags should starts from `ff_` or `fflag_` in lower case. Please check spelling in `.Values.global.featureFlags`
 {{- end -}}
 {{- end -}}
@@ -195,7 +199,7 @@ ls-app:
 {{- define "ls.checkConfig.pGandRedisCIonly" -}}
 {{- if and (.Values.enterprise.enabled) (not .Values.ci) -}}
 {{- if or .Values.redis.enabled .Values.postgresql.enabled }}
-ls-app:
+Label Studio:
   Redis/PostgreSQL: provided Helm chart dependencies should be used only for CI purposes.
 {{- end -}}
 {{- end -}}
@@ -204,9 +208,11 @@ ls-app:
 
 {{/* Ensure that the license is set */}}
 {{- define "lse.checkConfig.ensureLicense" -}}
+{{- if not .Values.checkConfig.skipEnvValues }}
 {{- if and (.Values.enterprise.enabled) (not (hasKey .Values.global.extraEnvironmentVars "LICENSE")) (not .Values.enterprise.enterpriseLicense.secretName) -}}
 Label Studio Enterprise:
   License: License file should be set either using k8s secret (`.Values.enterprise.enterpriseLicense.secretName`, `.Values.enterprise.enterpriseLicense.secretKey`) or as URL in `.Values.global.extraEnvironmentVars.LICENSE`
+{{- end -}}
 {{- end -}}
 {{- end -}}
 {{/* END ls.checkConfig.ensureLicense */}}

--- a/heartex/label-studio/values.schema.json
+++ b/heartex/label-studio/values.schema.json
@@ -1043,6 +1043,15 @@
     },
     "cloud_provider": {
       "type": "string"
+    },
+    "checkConfig": {
+      "type": "object",
+      "properties": {
+        "skipEnvValues": {
+          "type": "boolean"
+        }
+      },
+      "additionalProperties": false
     }
   },
   "additionalProperties": false

--- a/heartex/label-studio/values.yaml
+++ b/heartex/label-studio/values.yaml
@@ -523,3 +523,6 @@ redis:
 
 ci: false
 clusterDomain: cluster.local
+
+checkConfig:
+  skipEnvValues: false


### PR DESCRIPTION
### Description of the change

Allow to skip mandatory env variables validation check. 

### Benefits

This is useful for cases when someone uses other solution to inject env variable, e.g vault injector

### Possible drawbacks

No

### Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Chart version bumped in `Chart.yaml` according to [semver](http://semver.org/). This is *not necessary* when the changes only affect README.md files.
- [x] Input Validation completed with `values.schema.json`.
- [x] Variables are documented in the values.yaml and added to the `README.md`.
- [x] Title of the pull request follows this pattern [heartex/<name_of_the_chart>] Descriptive title
